### PR TITLE
Fix `Type 'T' has no member 'execute'`

### DIFF
--- a/Sources/Promise/Promise+Async.swift
+++ b/Sources/Promise/Promise+Async.swift
@@ -42,12 +42,12 @@ final public class Await {
     
     @usableFromInline init() {}
     
-    static public func | <T, Failure>(await: Await, promise: Promise<T, Failure>) throws -> T {
-        try await.execute(promise: promise)
+    static public func | <T, Failure>(await_: Await, promise: Promise<T, Failure>) throws -> T {
+        try await_.execute(promise: promise)
     }
 
-    static public func | <T>(await: Await, promise: Promise<T, Never>) -> T {
-        await.execute(promise: promise)
+    static public func | <T>(await_: Await, promise: Promise<T, Never>) -> T {
+        await_.execute(promise: promise)
     }
         
     public func execute<Output>(promise: Promise<Output, Never>) -> Output {


### PR DESCRIPTION
I'm trying to build https://github.com/ObuchiYuki/DevToysMac and came across `Type 'T' has no member 'execute'` erros in `Promise+Async.swift`. (looks like `await` is treated as a reserved word rather than a variable name)
I'm using Xcode 13.2.1.

![image](https://user-images.githubusercontent.com/1025246/151898498-177f2935-c402-4771-852a-7f4b8a899da8.png)

This PR renames `async` to `async_` to resolve the errors.



